### PR TITLE
[client] don't encode path to use query-params

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,23 @@
+.PHONY: all lint test benchmark deps
+
+# Default target
+all: fmt lint test benchmark
+
+fmt:
+	golangci-lint fmt
+
+# Lint the code using golangci-lint
+lint:
+	golangci-lint run --timeout=5m
+
+# Run tests with coverage
+test:
+	go test -race -shuffle=on -count=1 -covermode=atomic -coverpkg=./... -coverprofile=coverage.out ./...
+
+# Run benchmarks
+benchmark:
+	go test -run=^$$ -bench=. -benchmem ./... | tee benchmark.txt
+
+# Download dependencies
+deps:
+	go mod download

--- a/client_test.go
+++ b/client_test.go
@@ -222,7 +222,7 @@ func TestClient_Do(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := rest.NewClient(tt.fields.config)
+			c, _ := rest.NewClient(tt.fields.config)
 			err := c.Do(tt.args.ctx, tt.args.method, tt.args.path, tt.args.headers, tt.args.payload, tt.args.response)
 
 			if (err != nil) != tt.wantErr {
@@ -249,7 +249,7 @@ func TestInternalErrorClassification(t *testing.T) {
 	httpServer := setupTestServer(t)
 	defer httpServer.Close()
 
-	client := rest.NewClient(rest.Config{})
+	client, _ := rest.NewClient(rest.Config{})
 	err := client.Do(context.Background(), "", "/invalid", nil, math.NaN(), nil)
 	if !rest.IsInternalError(err) {
 		t.Error("Expected internal error for invalid payload")
@@ -257,7 +257,7 @@ func TestInternalErrorClassification(t *testing.T) {
 }
 
 func TestInfrastructureErrorClassification(t *testing.T) {
-	client := rest.NewClient(rest.Config{BaseURL: "http://localhost:1"})
+	client, _ := rest.NewClient(rest.Config{BaseURL: "http://localhost:1"})
 	err := client.Do(context.Background(), "GET", "/", nil, nil, nil)
 	if !rest.IsInfrastructureError(err) {
 		t.Error("Expected infrastructure error for unreachable host")
@@ -268,7 +268,7 @@ func TestAPIErrorBodyParsing(t *testing.T) {
 	httpServer := setupTestServer(t)
 	defer httpServer.Close()
 
-	client := rest.NewClient(rest.Config{BaseURL: httpServer.URL})
+	client, _ := rest.NewClient(rest.Config{BaseURL: httpServer.URL})
 	err := client.Do(context.Background(), "GET", "/400", nil, nil, nil)
 
 	apiErr, ok := rest.AsAPIError(err)

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,8 @@ import (
 )
 
 var (
-	ErrEmptyMethod    = errors.New("empty method")
+	ErrInvalidConfig  = errors.New("rest: invalid config")
+	ErrEmptyMethod    = errors.New("rest: empty method")
 	ErrEmptyErrorBody = errors.New("rest: empty error body")
 	ErrUnmarshalJSON  = errors.New("rest: failed to unmarshal body")
 )


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved URL resolution, encoding and query handling for requests.
  * Accept/Content-Type defaults refined when request bodies are present.

* **Breaking / Public API**
  * Client constructor now can return an error for invalid configuration; callers must handle it.
  * Added an exported error for invalid config and updated empty-method error text.

* **Chores**
  * Added Makefile with build, lint, test, benchmark and dependency targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->