### PR TITLE
[client] use `http.Header` instead of map

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -72,7 +72,7 @@ func TestClient_Do(t *testing.T) {
 		ctx      context.Context
 		method   string
 		path     string
-		headers  map[string]string
+		headers  http.Header
 		payload  any
 		response any
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved HTTP header handling to use the standard library's header representation, initializing and cloning headers to preserve immutability and applying them directly to requests for more consistent behavior.

* **Tests**
  * Updated client tests to reflect the new header representation and ensure header handling remains correct.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->